### PR TITLE
fix(nx-aws-cdk): implement cdk build executor to exclude lambda runti…

### DIFF
--- a/apps/nx-aws-cdk-e2e/tests/fixtures/lambda-executor/main-without-top-awaited.ts
+++ b/apps/nx-aws-cdk-e2e/tests/fixtures/lambda-executor/main-without-top-awaited.ts
@@ -7,12 +7,6 @@ type Event = {
   input: number
 }
 
-const asyncFunc = async () => {
-  return 'asyncResult'
-}
-
-const topLevelAwaited = await asyncFunc()
-
 export const handler: Handler = async (event: Event, context: Context) => {
   const message = `lambda handler. ${event.input} sqrt is ${getSqrt(event.input)}. ${directInternal(event.input)}`
   return {
@@ -20,6 +14,6 @@ export const handler: Handler = async (event: Event, context: Context) => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ event, context, message: message, topLevelAwaited }),
+    body: JSON.stringify({ event, context, message: message }),
   }
 }

--- a/apps/nx-aws-cdk-e2e/tests/nx-aws-cdk.spec.ts
+++ b/apps/nx-aws-cdk-e2e/tests/nx-aws-cdk.spec.ts
@@ -398,6 +398,10 @@ describe('cdk application', () => {
             },
           },
         )
+        await copyFile(
+          path.resolve(__dirname, 'fixtures/lambda-executor/main-without-top-awaited.ts'),
+          tmpProjPath(`apps/${project}/runtime/src/main.ts`),
+        )
         const deployResult = await runNxCommandAsync(
           `run ${infraProject}:cdk deploy ${className}StackLocal --require-approval never`,
         )

--- a/packages/nx-aws-cdk/executors.json
+++ b/packages/nx-aws-cdk/executors.json
@@ -15,6 +15,11 @@
       "implementation": "./src/executors/lambda-runtime/executor",
       "schema": "./src/executors/lambda-runtime/schema.json",
       "description": "lambda-runtime executor"
+    },
+    "cdk-build": {
+      "implementation": "./src/executors/cdk-build",
+      "schema": "./src/executors/cdk-build/schema.json",
+      "description": "cdk-build executor"
     }
   }
 }

--- a/packages/nx-aws-cdk/src/executors/cdk-build/index.spec.ts
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/index.spec.ts
@@ -1,0 +1,120 @@
+import { ExecutorContext } from '@nx/devkit'
+import { printDiagnostics, runTypeCheck } from '@nx/js'
+import { BuildResult, build } from 'esbuild'
+import { removeSync } from 'fs-extra'
+
+import { mockExecutorContext } from '../../utils/testing/executor'
+import { cdkBuildExecutor } from './index'
+import { buildEsbuildOptions } from './lib/build-esbuild-options'
+import { CdkBuildExecutorOptions } from './schema'
+
+jest.mock('@nx/js', () => ({
+  ...jest.requireActual('@nx/js'),
+  printDiagnostics: jest.fn(),
+  runTypeCheck: jest.fn(),
+}))
+jest.mock('esbuild', () => ({
+  build: jest.fn(),
+}))
+jest.mock('fs-extra', () => ({
+  ...jest.requireActual('fs-extra'),
+  removeSync: jest.fn(),
+}))
+jest.mock('./lib/build-esbuild-options', () => ({
+  buildEsbuildOptions: jest.fn(),
+}))
+
+const mockedPrintDiagnostics = jest.mocked(printDiagnostics)
+const mockedRunTypeCheck = jest.mocked(runTypeCheck)
+const mockedEsbuildBuild = jest.mocked(build)
+const mockedRemoveSync = jest.mocked(removeSync)
+const mockedBuildEsbuildOptions = jest.mocked(buildEsbuildOptions)
+
+describe('cdkBuildExecutor', () => {
+  const options: CdkBuildExecutorOptions = {
+    main: 'apps/cdk/src/main.ts',
+    outputPath: 'dist/apps/cdk',
+    tsConfig: 'apps/cdk/tsconfig.app.json',
+  }
+  const context: ExecutorContext = mockExecutorContext('cdk')
+  const mockTypeCheckResult = {
+    warnings: [],
+    errors: [],
+    inputFilesCount: 1,
+    totalFilesCount: 1,
+    incremental: false,
+  }
+  const mockEsbuildOptions = {
+    entryPoints: [options.main],
+    outdir: options.outputPath,
+    bundle: true,
+  }
+
+  beforeEach(() => {
+    mockedRunTypeCheck.mockResolvedValue(mockTypeCheckResult)
+    mockedBuildEsbuildOptions.mockReturnValue(mockEsbuildOptions)
+    mockedEsbuildBuild.mockResolvedValue({ errors: [] } as never as BuildResult)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should build successfully', async () => {
+    await expectExecutorSuccess(options, context)
+
+    expect(mockedRemoveSync).not.toHaveBeenCalled()
+    expect(mockedRunTypeCheck).toHaveBeenCalled()
+    expect(mockedEsbuildBuild).toHaveBeenCalledWith(mockEsbuildOptions)
+  })
+
+  it('should delete output path before building', async () => {
+    await expectExecutorSuccess({ ...options, deleteOutputPath: true }, context)
+
+    expect(mockedRemoveSync).toHaveBeenCalledWith(options.outputPath)
+  })
+
+  it('should fail if type check failed', async () => {
+    const typeCheckErrors = ['type check error']
+    mockedRunTypeCheck.mockResolvedValueOnce({ ...mockTypeCheckResult, errors: typeCheckErrors })
+
+    await expectExecutorError(options, context)
+    expect(mockedPrintDiagnostics).toHaveBeenCalledWith(typeCheckErrors, [])
+  })
+
+  it('should fail if esbuild build failed', async () => {
+    const buildErrors = ['esbuild error']
+    mockedEsbuildBuild.mockResolvedValueOnce({ errors: buildErrors } as never as BuildResult)
+
+    await expectExecutorError(options, context)
+  })
+})
+
+const expectExecutorSuccess = async (options: CdkBuildExecutorOptions, context: ExecutorContext) => {
+  const output = await cdkBuildExecutor(options, context)
+  for await (const res of output) {
+    expect(res.success).toBe(true)
+  }
+}
+
+const expectExecutorError = async (
+  options: CdkBuildExecutorOptions,
+  context: ExecutorContext,
+  errorMessage?: string,
+) => {
+  let expectedError
+  try {
+    let finalResult = true
+    for await (const res of cdkBuildExecutor(options, context)) {
+      finalResult = finalResult && res.success
+    }
+    expect(finalResult).toBe(false)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    expectedError = e
+    if (e.matcherResult) {
+      throw e
+    }
+  }
+  if (errorMessage) expect(expectedError).toEqual(new Error(errorMessage))
+}

--- a/packages/nx-aws-cdk/src/executors/cdk-build/index.ts
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/index.ts
@@ -1,0 +1,53 @@
+import type { ExecutorContext } from '@nx/devkit'
+import { TypeCheckOptions, runTypeCheck as _runTypeCheck, printDiagnostics } from '@nx/js'
+import * as esbuild from 'esbuild'
+import { removeSync } from 'fs-extra'
+
+import { buildEsbuildOptions } from './lib/build-esbuild-options'
+import { CdkBuildExecutorOptions } from './schema'
+
+export async function* cdkBuildExecutor(options: CdkBuildExecutorOptions, context: ExecutorContext) {
+  if (options.deleteOutputPath) removeSync(options.outputPath)
+
+  const { errors } = await runTypeCheck(options, context)
+  if (errors && errors.length > 0) {
+    yield { success: false }
+    return
+  }
+
+  const esbuildOptions = buildEsbuildOptions(options, context)
+  const buildResult = await esbuild.build(esbuildOptions)
+
+  yield {
+    success: buildResult.errors.length === 0,
+  }
+}
+
+function getTypeCheckOptions(options: CdkBuildExecutorOptions, context: ExecutorContext) {
+  const { tsConfig } = options
+
+  const typeCheckOptions: TypeCheckOptions = {
+    // TODO(jack): Add support for d.ts declaration files -- once the `@nx/js:tsc` changes are in we can use the same logic.
+    mode: 'noEmit',
+    tsConfigPath: tsConfig,
+    // outDir: outputPath,
+    workspaceRoot: context.root,
+    rootDir: context.root,
+  }
+
+  return typeCheckOptions
+}
+
+async function runTypeCheck(options: CdkBuildExecutorOptions, context: ExecutorContext) {
+  const { errors, warnings } = await _runTypeCheck(getTypeCheckOptions(options, context))
+  const hasErrors = errors && errors.length > 0
+  const hasWarnings = warnings && warnings.length > 0
+
+  if (hasErrors || hasWarnings) {
+    await printDiagnostics(errors, warnings)
+  }
+
+  return { errors, warnings }
+}
+
+export default cdkBuildExecutor

--- a/packages/nx-aws-cdk/src/executors/cdk-build/lib/build-esbuild-options.spec.ts
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/lib/build-esbuild-options.spec.ts
@@ -1,0 +1,113 @@
+import { ExecutorContext } from '@nx/devkit'
+import { mkdirSync, writeFileSync } from 'fs'
+
+import { getEntryPoints } from '../../../utils/esbuild'
+import { mockExecutorContext } from '../../../utils/testing/executor'
+import { getTsConfigCompilerPaths } from '../../../utils/workspace'
+import { CdkBuildExecutorOptions } from '../schema'
+import { buildEsbuildOptions } from './build-esbuild-options'
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}))
+jest.mock('../../../utils/esbuild', () => ({
+  getEntryPoints: jest.fn(),
+}))
+jest.mock('../../../utils/workspace', () => ({
+  getTsConfigCompilerPaths: jest.fn(),
+}))
+
+const mockedMkdirSync = jest.mocked(mkdirSync)
+const mockedWriteFileSync = jest.mocked(writeFileSync)
+const mockedGetEntryPoints = jest.mocked(getEntryPoints)
+const mockedGetTsConfigCompilerPaths = jest.mocked(getTsConfigCompilerPaths)
+
+describe('buildEsbuildOptions', () => {
+  const options: CdkBuildExecutorOptions = {
+    main: 'apps/cdk/src/main.ts',
+    outputPath: 'dist/apps/cdk',
+    tsConfig: 'apps/cdk/tsconfig.app.json',
+  }
+  const context: ExecutorContext = mockExecutorContext('cdk')
+
+  beforeEach(() => {
+    mockedGetTsConfigCompilerPaths.mockReturnValue({
+      '@testproj/lambda1-infra': ['apps/lambda1/infra/src/index.ts'],
+      '@testproj/lambda2-infra': ['apps/lambda2/infra/src/index.ts'],
+      '@testproj/utils': ['libs/utils/src/index.ts'],
+    })
+    mockedGetEntryPoints.mockReturnValue([
+      'apps/lambda1/infra/src/index.ts',
+      'apps/lambda1/infra/src/lib.ts',
+      'apps/lambda2/infra/src/index.ts',
+      'apps/lambda2/infra/src/lib.ts',
+      'libs/utils/src/index.ts',
+    ])
+  })
+
+  it('should return esbuild options', () => {
+    const result = buildEsbuildOptions(options, context)
+
+    expect(mockedMkdirSync).toHaveBeenCalledWith('/root/tmp/proj', { recursive: true })
+    expect(mockedWriteFileSync).toHaveBeenCalledWith(
+      '/root/tmp/proj/main-with-require-overrides.js',
+      expect.any(String),
+    )
+    expect(mockedWriteFileSync.mock.calls![0]![1]).toContain("require('./apps/cdk/src/main.js');")
+    expect(mockedWriteFileSync.mock.calls![0]![1]).toContain(
+      'const manifest = [{"module":"@testproj/lambda1-infra","pattern":"apps/lambda1/infra/src/index.ts",' +
+        '"exactMatch":"apps/lambda1/infra/src/index.js"},{"module":"@testproj/lambda2-infra","pattern":"apps/lambda2/infra/src/index.ts",' +
+        '"exactMatch":"apps/lambda2/infra/src/index.js"},{"module":"@testproj/utils","pattern":"libs/utils/src/index.ts",' +
+        '"exactMatch":"libs/utils/src/index.js"}];',
+    )
+
+    expect(result).toEqual({
+      entryNames: '[dir]/[name]',
+      bundle: false,
+      platform: 'node',
+      target: 'esnext',
+      tsconfig: options.tsConfig,
+      format: 'cjs',
+      outExtension: {
+        '.js': '.js',
+      },
+      outdir: options.outputPath,
+      entryPoints: [
+        {
+          in: '/root/tmp/proj/main-with-require-overrides.js',
+          out: 'main',
+        },
+        {
+          in: 'apps/lambda1/infra/src/index.ts',
+          out: 'apps/lambda1/infra/src/index',
+        },
+        {
+          in: 'apps/lambda1/infra/src/lib.ts',
+          out: 'apps/lambda1/infra/src/lib',
+        },
+        {
+          in: 'apps/lambda2/infra/src/index.ts',
+          out: 'apps/lambda2/infra/src/index',
+        },
+        {
+          in: 'apps/lambda2/infra/src/lib.ts',
+          out: 'apps/lambda2/infra/src/lib',
+        },
+        {
+          in: 'libs/utils/src/index.ts',
+          out: 'libs/utils/src/index',
+        },
+      ],
+    })
+  })
+
+  it('shoudl throw if main file conflicting generated entry point', () => {
+    expect(() => buildEsbuildOptions({ ...options, main: 'main.ts' }, context)).toThrow(
+      new Error(
+        `There is a conflict between Nx-generated main file and the project's main file. Main file should be under src/ folder.`,
+      ),
+    )
+  })
+})

--- a/packages/nx-aws-cdk/src/executors/cdk-build/lib/build-esbuild-options.ts
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/lib/build-esbuild-options.ts
@@ -1,0 +1,200 @@
+import { ExecutorContext, joinPathFragments, normalizePath } from '@nx/devkit'
+import * as esbuild from 'esbuild'
+import { mkdirSync, writeFileSync } from 'fs'
+import * as path from 'path'
+
+import { getEntryPoints } from '../../../utils/esbuild'
+import { getTsConfigCompilerPaths } from '../../../utils/workspace'
+import { CdkBuildExecutorOptions } from '../schema'
+
+export const buildEsbuildOptions = (
+  options: CdkBuildExecutorOptions,
+  context: ExecutorContext,
+): esbuild.BuildOptions => {
+  const outExtension = '.js'
+  const esbuildOptions: esbuild.BuildOptions = {
+    entryNames: '[dir]/[name]',
+    bundle: false,
+    platform: 'node',
+    target: 'esnext',
+    tsconfig: options.tsConfig,
+    format: 'cjs',
+    outExtension: {
+      '.js': outExtension,
+    },
+    outdir: options.outputPath,
+  }
+
+  const entryPoints = [options.main]
+
+  // When target platform Node and target format is CJS, then also transpile workspace libs used by the app.
+  // Provide a `require` override in the main entry file so workspace libs can be loaded when running the app.
+  const paths = getTsConfigCompilerPaths(context)
+  const entryPointsFromProjects = getEntryPoints(context.projectName!, context, {
+    initialTsConfigFileName: options.tsConfig,
+    initialEntryPoints: entryPoints,
+    recursive: true,
+    excludeImplicit: true,
+  })
+
+  esbuildOptions.entryPoints = [
+    // Write a main entry file that registers workspace libs and then calls the user-defined main.
+    writeTmpEntryWithRequireOverrides(paths, outExtension, options, context),
+    ...entryPointsFromProjects.map((f) => {
+      /**
+       * Maintain same directory structure as the workspace, so that other workspace libs may be used by the project.
+       * dist
+       * └── apps
+       *     └── demo
+       *         ├── apps
+       *         │   └── demo
+       *         │       └── src
+       *         │           └── main.js (requires '@acme/utils' which is mapped to libs/utils/src/index.js)
+       *         ├── libs
+       *         │   └── utils
+       *         │       └── src
+       *         │           └── index.js
+       *         └── main.js (entry with require overrides)
+       */
+      const { dir, name } = path.parse(f)
+      return {
+        in: f,
+        out: path.join(dir, name),
+      }
+    }),
+  ]
+
+  return esbuildOptions
+}
+
+const writeTmpEntryWithRequireOverrides = (
+  paths: Record<string, string[]>,
+  outExtension: '.cjs' | '.js' | '.mjs',
+  options: CdkBuildExecutorOptions,
+  context: ExecutorContext,
+): { in: string; out: string } => {
+  const project = context.projectGraph!.nodes[context.projectName!]!
+  // Write a temp main entry source that registers workspace libs.
+  const tmpPath = path.join(context.root, 'tmp', project.name)
+  mkdirSync(tmpPath, { recursive: true })
+
+  const { name: mainFileName, dir: mainPathRelativeToDist } = path.parse(options.main)
+  const mainWithRequireOverridesInPath = path.join(tmpPath, `main-with-require-overrides.js`)
+  writeFileSync(
+    mainWithRequireOverridesInPath,
+    getRegisterFileContent(
+      paths,
+      `./${path.join(mainPathRelativeToDist, `${mainFileName}${outExtension}`)}`,
+      outExtension,
+    ),
+  )
+
+  let mainWithRequireOverridesOutPath: string
+  if (mainPathRelativeToDist === '' || mainPathRelativeToDist === '.') {
+    // If the user customized their entry such that it is not inside `src/` folder
+    throw new Error(
+      `There is a conflict between Nx-generated main file and the project's main file. Main file should be under src/ folder.`,
+    )
+  } else {
+    mainWithRequireOverridesOutPath = path.parse(mainFileName).name
+  }
+
+  return {
+    in: mainWithRequireOverridesInPath,
+    out: mainWithRequireOverridesOutPath,
+  }
+}
+
+type ManifestEntry = {
+  module: string
+  pattern: string
+  exactMatch?: string
+}
+
+const getRegisterFileContent = (paths: Record<string, string[]>, mainFile: string, outExtension: string) => {
+  mainFile = normalizePath(mainFile)
+
+  // Sort by longest prefix so imports match the most specific path.
+  const sortedKeys = Object.keys(paths).sort((a: string, b: string) => getPrefixLength(b) - getPrefixLength(a))
+  const manifest: Array<ManifestEntry> = sortedKeys.reduce((acc: ManifestEntry[], k) => {
+    let exactMatch: string | undefined
+
+    // Nx generates a single path entry.
+    // If more sophisticated setup is needed, we can consider tsconfig-paths.
+    const pattern = paths[k]![0]!
+
+    const manifestEntry: ManifestEntry = { module: k, pattern }
+
+    if (/.[cm]?ts$/.test(pattern)) {
+      // Path specifies a single entry point e.g. "a/b/src/index.ts".
+      // This is the default setup.
+      const { dir, name } = path.parse(pattern)
+      exactMatch = joinPathFragments(dir, `${name}${outExtension}`)
+      if (exactMatch) {
+        manifestEntry.exactMatch = exactMatch
+      }
+    }
+    acc.push(manifestEntry)
+    return acc
+  }, [])
+
+  return `
+/**
+ * IMPORTANT: Do not modify this file.
+ * This file allows the app to run without bundling in workspace libraries.
+ * Must be contained in the ".nx" folder inside the output path.
+ */
+const Module = require('module');
+const path = require('path');
+const fs = require('fs');
+const originalResolveFilename = Module._resolveFilename;
+const distPath = __dirname;
+const manifest = ${JSON.stringify(manifest)};
+
+Module._resolveFilename = function(request, parent) {
+  let found;
+  for (const entry of manifest) {
+    if (request === entry.module && entry.exactMatch) {
+      const entry = manifest.find((x) => request === x.module || request.startsWith(x.module + "/"));
+      const candidate = path.join(distPath, entry.exactMatch);
+      if (isFile(candidate)) {
+        found = candidate;
+        break;
+      }
+    } else {
+      const re = new RegExp(entry.module.replace(/\\*$/, "(?<rest>.*)"));
+      const match = request.match(re);
+
+      if (match?.groups) {
+        const candidate = path.join(distPath, entry.pattern.replace("*", ""), match.groups.rest + ".js");
+        if (isFile(candidate)) {
+          found = candidate;
+        }
+      }
+
+    }
+  }
+  if (found) {
+    const modifiedArguments = [found, ...[].slice.call(arguments, 1)];
+    return originalResolveFilename.apply(this, modifiedArguments);
+  } else {
+    return originalResolveFilename.apply(this, arguments);
+  }
+};
+
+function isFile(s) {
+  try {
+    return fs.statSync(s).isFile();
+  } catch (_e) {
+    return false;
+  }
+}
+
+// Call the user-defined main.
+require('${mainFile}');
+`
+}
+
+const getPrefixLength = (pattern: string): number => {
+  return pattern.substring(0, pattern.indexOf('*')).length
+}

--- a/packages/nx-aws-cdk/src/executors/cdk-build/schema.d.ts
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/schema.d.ts
@@ -1,0 +1,6 @@
+export interface CdkBuildExecutorOptions {
+  deleteOutputPath?: boolean
+  main: string
+  outputPath: string
+  tsConfig: string
+}

--- a/packages/nx-aws-cdk/src/executors/cdk-build/schema.json
+++ b/packages/nx-aws-cdk/src/executors/cdk-build/schema.json
@@ -1,0 +1,38 @@
+{
+  "version": 2,
+  "outputCapture": "direct-nodejs",
+  "title": "cdk build",
+  "description": "Bundle a package for cdk application",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "main": {
+      "type": "string",
+      "description": "The path to the entry file, relative to project.",
+      "alias": "entryFile",
+      "x-completion-type": "file",
+      "x-completion-glob": "**/*@(.js|.ts)",
+      "x-priority": "important"
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the generated files.",
+      "x-completion-type": "directory",
+      "x-priority": "important"
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The path to tsconfig file.",
+      "x-completion-type": "file",
+      "x-completion-glob": "tsconfig.*.json",
+      "x-priority": "important"
+    },
+    "deleteOutputPath": {
+      "type": "boolean",
+      "description": "Remove previous output before build.",
+      "alias": "clean",
+      "default": true
+    }
+  },
+  "required": ["tsConfig", "main", "outputPath"]
+}

--- a/packages/nx-aws-cdk/src/generators/aws-lambda/runtime-generator/index.spec.ts
+++ b/packages/nx-aws-cdk/src/generators/aws-lambda/runtime-generator/index.spec.ts
@@ -1,4 +1,4 @@
-import { Tree, readProjectConfiguration } from '@nx/devkit'
+import { Tree, readJson, readProjectConfiguration } from '@nx/devkit'
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
 
 import awsLambdaRuntimeApplicationGenerator from '.'
@@ -42,5 +42,13 @@ describe('awsLambdaRuntimeApplicationGenerator', () => {
     const projectConfig = readProjectConfiguration(tree, 'aws-lambda-runtime')
     expect(projectConfig.targets?.['build']).toBeUndefined()
     expect(projectConfig.targets?.['serve']).toBeUndefined()
+  })
+
+  it('should update tsconfig.app.json', async () => {
+    await awsLambdaRuntimeApplicationGenerator(tree, options)
+
+    const tsconfig = readJson(tree, 'apps/aws-lambda/runtime/tsconfig.app.json')
+    expect(tsconfig.compilerOptions.target).toContain('es2022')
+    expect(tsconfig.compilerOptions.module).toContain('es2022')
   })
 })

--- a/packages/nx-aws-cdk/src/generators/aws-lambda/runtime-generator/index.ts
+++ b/packages/nx-aws-cdk/src/generators/aws-lambda/runtime-generator/index.ts
@@ -5,6 +5,7 @@ import {
   generateFiles,
   readProjectConfiguration,
   runTasksInSerial,
+  updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit'
 import { applicationGenerator as nodeApplicationGenerator } from '@nx/node'
@@ -38,6 +39,18 @@ const updateAwsLambdaRuntumeProjectConfiguration = (tree: Tree, options: AwsLamb
   }
 
   updateProjectConfiguration(tree, options.name, projectConfig)
+}
+
+const updateAwsLambdaTsconfig = (tree: Tree, options: AwsLambdaRuntimeGeneratorOptions) => {
+  updateJson(tree, `${options.directory}/tsconfig.app.json`, (tsconfig) => {
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      target: 'es2022',
+      module: 'es2022',
+    }
+
+    return tsconfig
+  })
 }
 
 const addFiles = (
@@ -74,6 +87,7 @@ const awsLambdaRuntimeApplicationGenerator = async (
     addFiles(tree, normalizedOptions, 'jest-files')
   }
   updateAwsLambdaRuntumeProjectConfiguration(tree, normalizedOptions)
+  updateAwsLambdaTsconfig(tree, normalizedOptions)
 
   if (!normalizedOptions.skipFormat) {
     await formatFiles(tree)

--- a/packages/nx-aws-cdk/src/generators/cdk-application/index.spec.ts
+++ b/packages/nx-aws-cdk/src/generators/cdk-application/index.spec.ts
@@ -46,7 +46,7 @@ describe('cdk-application generator', () => {
 
     const config = readProjectConfiguration(tree, 'cdk')
 
-    expect(Object.keys(config?.targets || {})).toEqual(['build'])
+    expect(Object.keys(config?.targets || {})).toEqual([])
     expect(tree.exists('apps/cdk/cdk.json')).toBeTruthy()
     expect(tree.exists('apps/cdk/jest.config.ts')).toBeFalsy()
     expect(tree.exists('apps/cdk/src/main.ts')).toBeTruthy()
@@ -60,7 +60,7 @@ describe('cdk-application generator', () => {
     const config = readProjectConfiguration(tree, 'cdk')
     const nxConfig = readJson(tree, 'nx.json')
 
-    expect(Object.keys(config?.targets || {})).toEqual(['build'])
+    expect(Object.keys(config?.targets || {})).toEqual([])
     expect(nxConfig.plugins).toContainEqual({
       plugin: '@nx/jest/plugin',
       options: {
@@ -80,7 +80,7 @@ describe('cdk-application generator', () => {
 
     const config = readProjectConfiguration(tree, 'dir-cdk')
 
-    expect(Object.keys(config?.targets || {})).toEqual(['build'])
+    expect(Object.keys(config?.targets || {})).toEqual([])
     expect(tree.exists('apps/dir/cdk/cdk.json')).toBeTruthy()
     expect(tree.exists('apps/dir/cdk/jest.config.ts')).toBeTruthy()
     expect(tree.exists('apps/dir/cdk/src/main.ts')).toBeTruthy()

--- a/packages/nx-aws-cdk/src/generators/cdk-application/index.ts
+++ b/packages/nx-aws-cdk/src/generators/cdk-application/index.ts
@@ -71,13 +71,7 @@ const updateInfraProjectConfiguration = (tree: Tree, options: NormalizedSchema) 
   const projectConfig = readProjectConfiguration(tree, options.name)
   const projectTargets = projectConfig.targets ?? {}
   delete projectTargets['serve']
-
-  const buildTarget = projectTargets['build']
-  if (buildTarget) {
-    delete buildTarget.defaultConfiguration
-    delete buildTarget.configurations
-    buildTarget.options.deleteOutputPath = false
-  }
+  delete projectTargets['build']
 
   updateProjectConfiguration(tree, options.projectName, projectConfig)
 }

--- a/packages/nx-aws-cdk/src/generators/cdk-application/inferrence.spec.ts
+++ b/packages/nx-aws-cdk/src/generators/cdk-application/inferrence.spec.ts
@@ -56,6 +56,18 @@ describe('cdkInferrence', () => {
         projects: {
           '/path/to': {
             targets: {
+              build: {
+                cache: true,
+                dependsOn: ['^build'],
+                executor: '@routineless/nx-aws-cdk:cdk-build',
+                inputs: ['production', '^production'],
+                options: {
+                  main: '/path/to/src/main.ts',
+                  outputPath: 'dist//path/to',
+                  tsConfig: '/path/to/tsconfig.app.json',
+                },
+                outputs: ['{options.outputPath}'],
+              },
               localstack: {
                 executor: '@routineless/nx-aws-cdk:localstack',
               },

--- a/packages/nx-aws-cdk/src/generators/cdk-application/inferrence.ts
+++ b/packages/nx-aws-cdk/src/generators/cdk-application/inferrence.ts
@@ -11,6 +11,18 @@ const createCdkAppNode: CreateNodesFunction<NxAwsCdkPluginOptions> = (projectCon
     projects: {
       [projectRoot]: {
         targets: {
+          build: {
+            executor: '@routineless/nx-aws-cdk:cdk-build',
+            outputs: ['{options.outputPath}'],
+            options: {
+              outputPath: `dist/${projectRoot}`,
+              main: `${projectRoot}/src/main.ts`,
+              tsConfig: `${projectRoot}/tsconfig.app.json`,
+            },
+            cache: true,
+            dependsOn: ['^build'],
+            inputs: ['production', '^production'],
+          },
           localstack: {
             executor: '@routineless/nx-aws-cdk:localstack',
           },


### PR DESCRIPTION
…me from bundling

Initially cdk app used default esbuild executor that was trying to build lambda runtime apps. This prevents from using feature not supported by cjs giveen that cdk app is build using that format.

fix #52