### PR TITLE
fix(nx-aws-cdk): fix imports containing dot

### DIFF
--- a/packages/nx-aws-cdk/src/executors/lambda-runtime/lib/ast/modifications-util.ts
+++ b/packages/nx-aws-cdk/src/executors/lambda-runtime/lib/ast/modifications-util.ts
@@ -49,7 +49,7 @@ type ImportSpecifier =
   | { default?: never; namespace?: never; named: string }
 
 export const resolveReexportingName = (importedModule: string, importSpecifier: ImportSpecifier): string => {
-  const normalizedImportedModule = importedModule.replaceAll('/', '-').replaceAll('@', '')
+  const normalizedImportedModule = importedModule.replace(/[/.]/g, '-').replaceAll('@', '')
   if (importSpecifier.namespace) {
     return `${toCamelCase(normalizedImportedModule)}Namespace`
   }

--- a/packages/nx-aws-cdk/src/executors/lambda-runtime/lib/esbuild-helper.spec.ts
+++ b/packages/nx-aws-cdk/src/executors/lambda-runtime/lib/esbuild-helper.spec.ts
@@ -256,6 +256,15 @@ describe('esbuild-helper', () => {
               },
             ],
             [
+              '@some.module/name',
+              {
+                namespaceImport: false,
+                defaultImport: true,
+                sideEffectImport: false,
+                namedImports: new Set(),
+              },
+            ],
+            [
               'moment/min/moment-with-locales',
               { defaultImport: true, namespaceImport: false, sideEffectImport: true, namedImports: new Set() },
             ],
@@ -318,6 +327,10 @@ describe('esbuild-helper', () => {
           expect.stringContaining(
             "export { default as momentMinMomentWithLocalesDefault } from 'moment/min/moment-with-locales'",
           ),
+        )
+        expect(mockedWriteFile).toHaveBeenCalledWith(
+          `${workspaceRoot}/tmp/proj/external/index.js`,
+          expect.stringContaining("export { default as someModuleNameDefault } from '@some.module/name'"),
         )
         expect(mockedWriteFile).toHaveBeenCalledWith(
           `${workspaceRoot}/tmp/proj/external/index.js`,


### PR DESCRIPTION
Reexporting modules containt dot results in uresolvable module name. Fixing it by casting module name to camel case